### PR TITLE
L.Draw.Polyline has no more _onClick method

### DIFF
--- a/leaflet.measurecontrol.js
+++ b/leaflet.measurecontrol.js
@@ -63,8 +63,6 @@ L.Polyline.Measure = L.Draw.Polyline.extend({
             this._startShape();
             return;
         }
-
-        L.Draw.Polyline.prototype._onClick.call(this, e);
     },
 
     _getTooltipText: function() {


### PR DESCRIPTION
This targets the last stable version (0.2.3)
See https://github.com/Leaflet/Leaflet.draw/commit/8fa143262084e819128e478cd447b177e37d2e7e

Thanks :)
